### PR TITLE
add optional attribute: custom padding

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ legendClick = (label) =>{
   }}
   width={1000}
   height={800}
+  padding={0} // optional value, number that set the padding between bubbles
   showLegend={true} // optional value, pass false to disable the legend.
   legendPercentage={20} // number that represent the % of with that legend going to use.
   legendFont={{

--- a/src/react-bubble-chart-d3.js
+++ b/src/react-bubble-chart-d3.js
@@ -43,6 +43,7 @@ export default class BubbleChart extends Component {
       data,
       height,
       width,
+      padding,
       showLegend,
       legendPercentage,
     } = this.props;
@@ -55,7 +56,7 @@ export default class BubbleChart extends Component {
 
     const pack = d3.pack()
         .size([bubblesWidth * graph.zoom, bubblesWidth * graph.zoom])
-        .padding(0);
+        .padding(padding);
 
     // Process the data to have a hierarchy structure;
     const root = d3.hierarchy({children: data})
@@ -271,6 +272,7 @@ BubbleChart.propTypes = {
   }),
   width: PropTypes.number,
   height: PropTypes.number,
+  padding: PropTypes.number,
   showLegend: PropTypes.bool,
   legendPercentage: PropTypes.number,
   legendFont: PropTypes.shape({
@@ -300,6 +302,7 @@ BubbleChart.defaultProps = {
   },
   width: 1000,
   height: 800,
+  padding: 0,
   showLegend: true,
   legendPercentage: 20,
   legendFont: {


### PR DESCRIPTION
I modified few lines of snippet in order to give users little freedom of choosing padding between bubbles on their own. 
default value for padding is 0 ( same as original code )