### PR TITLE
Fixing Bubbles Cut off

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ graph: {
 }
 ```
 
+The **overflow** prop receive a boolean value if you want to make bubbles visible beyond its SVG element bounday.
+The default value is set to 'false':
+```javascript
+overflow={true}
+```
+
 The **legendFont**, **valueFont** and **labelFont** prop receive a configuration object to set the font-family, font-size, font-weight and color of the text:
 ```javascript
 // If you don't set this prop the default configuration will be this object.

--- a/src/react-bubble-chart-d3.js
+++ b/src/react-bubble-chart-d3.js
@@ -39,6 +39,7 @@ export default class BubbleChart extends Component {
 
   renderChart() {
     const {
+      overflow,
       graph,
       data,
       height,
@@ -49,6 +50,9 @@ export default class BubbleChart extends Component {
     } = this.props;
     // Reset the svg element to a empty state.
     this.svg.innerHTML = '';
+    // Allow bubbles overflowing its SVG container in visual aspect if props(overflow) is true.
+    if(overflow)
+      this.svg.style.overflow = "visible";
 
     const bubblesWidth = showLegend ? width * (1 - (legendPercentage / 100)) : width;
     const legendWidth = width - bubblesWidth;
@@ -265,6 +269,7 @@ export default class BubbleChart extends Component {
 }
 
 BubbleChart.propTypes = {
+  overflow: PropTypes.bool,
   graph: PropTypes.shape({
     zoom: PropTypes.number,
     offsetX: PropTypes.number,
@@ -295,6 +300,7 @@ BubbleChart.propTypes = {
   }),
 }
 BubbleChart.defaultProps = {
+  overflow: false,
   graph: {
     zoom: 1.1,
     offsetX: -0.05,


### PR DESCRIPTION
#18
I fixed bubbles in the chart getting cut off due to its SVG container boundary by passing overflow props to BubbleChart Component.